### PR TITLE
feat: include SDK version and project ID in Limelight CONNECT message and config object.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@getlimelight/sdk",
-  "version": "0.1.12",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@getlimelight/sdk",
-      "version": "0.1.12",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/react": "^16.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getlimelight/sdk",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "The react native debugger that actually works",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/__tests__/ConsoleInterceptor.test.ts
+++ b/src/__tests__/ConsoleInterceptor.test.ts
@@ -24,7 +24,7 @@ describe("ConsoleInterceptor", () => {
   });
 
   it("should intercept console.log", () => {
-    interceptor.setup({ enableConsole: true });
+    interceptor.setup({ enableConsole: true, projectKey: "project-123" });
 
     console.log("test message", { data: "value" });
 
@@ -38,7 +38,7 @@ describe("ConsoleInterceptor", () => {
   });
 
   it("should intercept all console methods", () => {
-    interceptor.setup({ enableConsole: true });
+    interceptor.setup({ enableConsole: true, projectKey: "project-123" });
 
     console.log("log");
     console.warn("warn");
@@ -77,6 +77,7 @@ describe("ConsoleInterceptor", () => {
     interceptor.setup({
       enableConsole: true,
       beforeSend,
+      projectKey: "project-123",
     });
 
     console.log("user log");
@@ -113,6 +114,7 @@ describe("ConsoleInterceptor", () => {
     interceptor.setup({
       enableConsole: true,
       beforeSend,
+      projectKey: "project-123",
     });
 
     console.log("blocked message");
@@ -124,7 +126,7 @@ describe("ConsoleInterceptor", () => {
   it("should restore original console on cleanup", () => {
     const original = console.log;
 
-    interceptor.setup({ enableConsole: true });
+    interceptor.setup({ enableConsole: true, projectKey: "project-123" });
     expect(console.log).not.toBe(original);
 
     interceptor.cleanup();

--- a/src/__tests__/LimelightClient.test.ts
+++ b/src/__tests__/LimelightClient.test.ts
@@ -49,6 +49,7 @@ describe("LimelightClient", () => {
       client.connect({
         serverUrl: "ws://localhost:8080",
         appName: "Test App",
+        projectKey: "project-123",
       });
 
       await expect(connectPromise).resolves.toBeDefined();
@@ -62,14 +63,20 @@ describe("LimelightClient", () => {
         mockServer.once("connection", () => resolve(true));
       });
 
-      client.connect({ serverUrl: "ws://localhost:8080" });
+      client.connect({
+        serverUrl: "ws://localhost:8080",
+        projectKey: "project-123",
+      });
       await firstConnect;
 
       // Wait for connection to be fully established
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       // Try to connect again
-      client.connect({ serverUrl: "ws://localhost:8080" });
+      client.connect({
+        serverUrl: "ws://localhost:8080",
+        projectKey: "project-123",
+      });
 
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining("Already connected")
@@ -95,7 +102,10 @@ describe("LimelightClient", () => {
       })) as any;
 
       // 3. Connect (this now uses our mock)
-      client.connect({ serverUrl: "ws://localhost:8080" });
+      client.connect({
+        serverUrl: "ws://localhost:8080",
+        projectKey: "project-123",
+      });
 
       // 4. Manually trigger the failure on the mock instance
       const wsInstance = (client as any).ws;
@@ -163,7 +173,10 @@ describe("LimelightClient", () => {
       });
 
       // Connect and wait for messages to flush
-      client.connect({ serverUrl: "ws://localhost:8080" });
+      client.connect({
+        serverUrl: "ws://localhost:8080",
+        projectKey: "project-123",
+      });
 
       await messagePromise;
 

--- a/src/__tests__/NetworkInterceptor.test.ts
+++ b/src/__tests__/NetworkInterceptor.test.ts
@@ -43,6 +43,7 @@ describe("NetworkInterceptor", () => {
       interceptor.setup({
         enableNetworkInspector: true,
         enableGraphQL: false,
+        projectKey: "project-123",
       });
 
       await fetch("https://api.example.com/test", {
@@ -73,7 +74,11 @@ describe("NetworkInterceptor", () => {
         })
       );
 
-      interceptor.setup({ enableNetworkInspector: true, enableGraphQL: true });
+      interceptor.setup({
+        enableNetworkInspector: true,
+        enableGraphQL: true,
+        projectKey: "project-123",
+      });
 
       await fetch("https://api.example.com/graphql", {
         method: "POST",
@@ -102,7 +107,10 @@ describe("NetworkInterceptor", () => {
     it("should handle fetch errors", async () => {
       mockFetch.mockRejectedValue(new Error("Network error"));
 
-      interceptor.setup({ enableNetworkInspector: true });
+      interceptor.setup({
+        enableNetworkInspector: true,
+        projectKey: "project-123",
+      });
 
       await expect(fetch("https://api.example.com/test")).rejects.toThrow(
         "Network error"
@@ -129,6 +137,7 @@ describe("NetworkInterceptor", () => {
       interceptor.setup({
         enableNetworkInspector: true,
         beforeSend,
+        projectKey: "project-123",
       });
 
       await fetch("https://api.example.com/sensitive-data");
@@ -140,8 +149,14 @@ describe("NetworkInterceptor", () => {
     it("should prevent double setup", () => {
       const consoleSpy = vi.spyOn(console, "warn");
 
-      interceptor.setup({ enableNetworkInspector: true });
-      interceptor.setup({ enableNetworkInspector: true });
+      interceptor.setup({
+        enableNetworkInspector: true,
+        projectKey: "project-123",
+      });
+      interceptor.setup({
+        enableNetworkInspector: true,
+        projectKey: "project-123",
+      });
 
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining("already set up")
@@ -153,7 +168,10 @@ describe("NetworkInterceptor", () => {
     it("should restore original fetch", () => {
       const fetchBeforeSetup = global.fetch;
 
-      interceptor.setup({ enableNetworkInspector: true });
+      interceptor.setup({
+        enableNetworkInspector: true,
+        projectKey: "project-123",
+      });
       expect(global.fetch).not.toBe(fetchBeforeSetup);
 
       interceptor.cleanup();
@@ -165,7 +183,10 @@ describe("NetworkInterceptor", () => {
     it("should handle Request object as input", async () => {
       mockFetch.mockResolvedValue(new Response("ok"));
 
-      interceptor.setup({ enableNetworkInspector: true });
+      interceptor.setup({
+        enableNetworkInspector: true,
+        projectKey: "project-123",
+      });
 
       const request = new Request("https://api.example.com/test", {
         method: "POST",
@@ -184,7 +205,10 @@ describe("NetworkInterceptor", () => {
     it("should handle URL object as input", async () => {
       mockFetch.mockResolvedValue(new Response("ok"));
 
-      interceptor.setup({ enableNetworkInspector: true });
+      interceptor.setup({
+        enableNetworkInspector: true,
+        projectKey: "project-123",
+      });
 
       await fetch(new URL("https://api.example.com/test"));
 
@@ -198,7 +222,10 @@ describe("NetworkInterceptor", () => {
     it("should redact sensitive headers", async () => {
       mockFetch.mockResolvedValue(new Response("ok"));
 
-      interceptor.setup({ enableNetworkInspector: true });
+      interceptor.setup({
+        enableNetworkInspector: true,
+        projectKey: "project-123",
+      });
 
       await fetch("https://api.example.com/test", {
         headers: {

--- a/src/__tests__/XHRInterceptor.test.ts
+++ b/src/__tests__/XHRInterceptor.test.ts
@@ -18,7 +18,10 @@ describe("XHRInterceptor", () => {
   });
 
   it("should intercept XHR requests", async () => {
-    interceptor.setup({ enableNetworkInspector: true });
+    interceptor.setup({
+      enableNetworkInspector: true,
+      projectKey: "project-123",
+    });
 
     const xhr = new XMLHttpRequest();
 
@@ -48,7 +51,10 @@ describe("XHRInterceptor", () => {
   });
 
   it("should capture request headers", () => {
-    interceptor.setup({ enableNetworkInspector: true });
+    interceptor.setup({
+      enableNetworkInspector: true,
+      projectKey: "project-123",
+    });
 
     const xhr = new XMLHttpRequest();
     xhr.open("POST", "https://api.example.com/test");
@@ -63,7 +69,10 @@ describe("XHRInterceptor", () => {
   });
 
   it("should handle XHR errors", async () => {
-    interceptor.setup({ enableNetworkInspector: true });
+    interceptor.setup({
+      enableNetworkInspector: true,
+      projectKey: "project-123",
+    });
 
     const xhr = new XMLHttpRequest();
 
@@ -85,7 +94,10 @@ describe("XHRInterceptor", () => {
   });
 
   it("should handle XHR abort", async () => {
-    interceptor.setup({ enableNetworkInspector: true });
+    interceptor.setup({
+      enableNetworkInspector: true,
+      projectKey: "project-123",
+    });
 
     const xhr = new XMLHttpRequest();
 
@@ -108,7 +120,10 @@ describe("XHRInterceptor", () => {
   });
 
   it("should clean up event listeners after request completes", async () => {
-    interceptor.setup({ enableNetworkInspector: true });
+    interceptor.setup({
+      enableNetworkInspector: true,
+      projectKey: "project-123",
+    });
 
     const xhr = new XMLHttpRequest();
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -35,3 +35,10 @@ export const DEFAULT_PORT = 9090;
  * The WebSocket path for Limelight connections.
  */
 export const WS_PATH = "/limelight";
+
+/**
+ * The current SDK version of Limelight.
+ */
+declare const __SDK_VERSION__: string;
+export const SDK_VERSION =
+  typeof __SDK_VERSION__ !== "undefined" ? __SDK_VERSION__ : "test-version";

--- a/src/types/limelight.ts
+++ b/src/types/limelight.ts
@@ -29,6 +29,10 @@ import {
  */
 export interface LimelightConfig {
   /**
+   * The unique project key for authenticating with the Limelight server.
+   */
+  projectKey: string;
+  /**
    * The platform of the application (e.g., "ios", "android").
    */
   platform?: string;
@@ -73,10 +77,12 @@ export interface ConnectionEvent {
   phase: "CONNECT" | "DISCONNECT";
   sessionId: string;
   timestamp: number;
-  data?: {
+  data: {
     appName?: string;
     platform?: string;
     reason?: string; // for disconnect
+    projectKey: string;
+    sdkVersion: string;
   };
 }
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "tsup";
+import pkg from "./package.json";
 
 export default defineConfig({
   entry: ["src/index.ts"],
@@ -7,6 +8,9 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   external: [],
+  define: {
+    __SDK_VERSION__: JSON.stringify(pkg.version),
+  },
   esbuildOptions(options) {
     options.alias = {
       "@": "./src",


### PR DESCRIPTION
### Summary
This PR adds a SDK_VERSION constant to the Limelight SDK, which is sent in the WebSocket CONNECT message. It also requires a projectKey in the configuration, which ensures that events are scoped to the correct project. These changes allow the server to detect if a client is using an outdated SDK version and prevent cross-project data visibility.

### Changes
- Added `SDK_VERSION` from package.json
- Updated `LimelightClient.connect()` to include `sdkVersion` in message
- Updated tsup build to replace `__SDK_VERSION__` placeholder
- Made projectKey required in configuration to scope events to a project

### Notes
- This is a non-breaking change.
- Interceptor setup is unchanged for production.
- Verified locally in browser environment that sdkVersion and projectKey are sent correctly.

### Related Issues
N/A
